### PR TITLE
feat: use SqlAlchemy for Postgres

### DIFF
--- a/LINZ/CORS_Analyst.py
+++ b/LINZ/CORS_Analyst.py
@@ -80,9 +80,9 @@ class CORS_Analyst(object):
         self.loadDeformationModel()
 
     def boolParser(self, value):
-        if value == None:
+        if value is None:
             return False
-        elif type(value) == bool:
+        elif type(value) is bool:
             return value
         elif str(value).lower() == "yes":
             return True


### PR DESCRIPTION
This PR amends the postgres handling to use SqlAlchemy rather than directly using psycopg2.

This change is to avoid warnings from pandas read_sql function which has deprecated use of Postgres unless it is via SqlAlchemy.

Also in this PR I have changed the default queries used by PostgresTimeseries to align them with the gnss-datum-processing-infrastructure coordinate database schema.